### PR TITLE
プラン詳細情報をダイアログで表示 #18

### DIFF
--- a/backend/app/controllers/api/v1/plans_controller.rb
+++ b/backend/app/controllers/api/v1/plans_controller.rb
@@ -4,7 +4,7 @@ module Api
 
       def index
         @plans = Plan.all.includes(:user)
-        render json: @plans.as_json(includes: [:user])
+        render json: @plans.as_json(include: [{ user: { only: %w[icon name] } }])
       end
       
       def create

--- a/front/components/AddPlanBtn.vue
+++ b/front/components/AddPlanBtn.vue
@@ -5,10 +5,15 @@
       fixed
       right
       bottom
-      color="red"
       large
+      dark
+      color="blue-grey"
       @click.stop="openPlanDialog(true)"
-    >募集</v-btn>
+    >
+      <v-icon dark>
+        mdi-pencil
+      </v-icon>
+      投稿</v-btn>
     <v-dialog
       v-model="planDialog"
       persistent
@@ -237,8 +242,10 @@ export default {
       clearMessages: "errorMessage/clearMessages",
     }),
     postPlan() {
-      this.plan['user_id'] = this.$store.state.currentUser.user.id
+      let user_id = this.$store.state.currentUser.user.id
+      this.plan['user_id'] = user_id
       this.createPlan(this.plan)
+      this.$router.push({ path: `users/${user_id}`})
     },
   },
   watch: {

--- a/front/components/PlanCard.vue
+++ b/front/components/PlanCard.vue
@@ -24,11 +24,21 @@
               
             </p>
             <div class="card-title">
-              <v-avatar color="#445CB0">
-                <v-icon dark>
-                  mdi-account-circle
-                </v-icon>
-              </v-avatar>
+          <nuxt-link 
+            style="text-decoration: none;" 
+            :to="{ path: `/users/${plan.user_id}` }">
+            <v-avatar v-if="plan.user.icon.url">
+              <v-img
+                alt="user"
+                :src="plan.user.icon.url"
+              />
+            </v-avatar >
+            <v-avatar v-else color="#445CB0">
+              <v-icon dark>
+                mdi-account-circle
+              </v-icon>
+            </v-avatar>
+          </nuxt-link>
               <div class="title-text">{{plan.title}}</div>
             </div>
             <p>
@@ -47,31 +57,41 @@
             </div>
           </v-card-text>
           <v-card-actions>
-            <v-btn
-              color="primary"
-            >
-              詳細情報
-            </v-btn>
+            <template>
+              <v-btn
+                color="primary"
+                @click.stop="getDetailPlan(plan)"
+              >
+                詳細情報
+              </v-btn>
+            </template>
             <div style="margin: 0 0 0 auto;">定員: [ 1 / {{plan.join_limit}} ]</div>
           </v-card-actions>
         </v-card>
       </v-col>
+      <plan-detail-dialog v-if="clickPlan" :plan="clickPlan" @close="closeDialog"/>
     </v-row>
   </div>
 </template>
 
 <script>
 import { mapGetters, mapActions} from 'vuex'
+import PlanDetailDialog from '~/components/PlanDetailDialog'
 
 export default {
+  components: {
+    PlanDetailDialog
+  },
   data() {
     return {
       loading: false,
+      planDialog: false,
+      clickPlan: null
     }
   },
   computed: {
     ...mapGetters({
-      plans: 'plan/plans'
+      plans: 'plan/plans',
     })
   },
   created() {
@@ -81,8 +101,18 @@ export default {
   },
   methods: {
     ...mapActions({
-      getPlans: 'plan/getPlans'
-    })
+      getPlans: 'plan/getPlans',
+      setUser: 'user/setUser'
+    }),
+    getDetailPlan(plan) {
+      this.clickPlan = plan
+      this.setUser(plan.user_id)
+      this.planDialog = true
+    },
+    closeDialog() {
+      this.planDialog = false
+      this.clickPlan = null
+    }
   }
 }
 </script>

--- a/front/components/PlanDetailDialog.vue
+++ b/front/components/PlanDetailDialog.vue
@@ -1,0 +1,101 @@
+<template>
+  <v-dialog
+    v-model="planDialog"
+    max-width="500px"
+  >
+    <v-card rounded="lg">
+      <v-card-title style="display:flex;">
+        <div style="margin-top: 15px">
+          <nuxt-link style="text-decoration: none;" :to="{ path: `/users/${plan.user_id}` }">
+            <v-avatar v-if="plan.user.icon.url" size="56">
+              <v-img
+                alt="user"
+                :src="plan.user.icon.url"
+              />
+            </v-avatar >
+            <v-avatar v-else color="#445CB0">
+              <v-icon dark>
+                mdi-account-circle
+              </v-icon>
+            </v-avatar>
+          </nuxt-link>
+          <p style="float:right; line-height:56px;">
+            {{plan.user.name}}
+          </p>
+        </div>
+        <div>
+          <v-chip 
+            color="primary"
+            outlined
+            style="margin-left: 15px"
+          >
+            {{ plan.event_cls }}
+          </v-chip>
+          <v-chip 
+            color="primary"
+            outlined
+            style="margin-left: 5px"
+          >
+            {{plan.train_strength}}
+          </v-chip>
+        </div>
+        <div style=" margin: 0 0 0 auto">
+          <v-btn
+            color="orange">
+            参加
+          </v-btn>
+        </div>
+      </v-card-title>
+      <v-card-text class="mt-3" style="white-space:pre-line; word-wrap:break-word;">
+        <strong>{{plan.title}}</strong>
+        <v-spacer class="mt-5"></v-spacer>
+        <p>
+          <v-icon color="orange">mdi-calendar</v-icon>
+          開催日時 : <strong>{{$dayjs(plan.start_ymd).format('MM月DD日')}} {{$dayjs(plan.start_time).format('HH:mm')}}</strong>
+          所要時間 : <strong>{{plan.duration}}時間</strong></p>
+        <p>
+          <v-icon color="orange">mdi-map-marker</v-icon>
+          集合場所 : <strong>{{plan.place}}</strong>
+          エリア区分 : <strong>{{plan.prefecture}}</strong></p>
+        <v-spacer class="mt-5"></v-spacer>
+        <p style=" display:inline; border-bottom:solid 2px gray">詳細内容</p>
+        <p >{{plan.detail}}</p>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-btn
+          text
+          @click="planDialog = false"
+        >
+        <v-icon>mdi-close</v-icon>
+        <div style="line-height:24px">閉じる</div> 
+        </v-btn>
+        <div style="margin: 0 0 0 auto;">定員: [ 1 / {{plan.join_limit}} ]</div>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+export default {
+  props: {
+    plan: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      planDialog: true
+    }
+  },
+  methods: {
+  },
+  watch: {
+    planDialog() {
+      this.$emit("close")
+    }
+  }
+}
+</script>

--- a/front/components/mypage/MypageTabs.vue
+++ b/front/components/mypage/MypageTabs.vue
@@ -16,16 +16,16 @@
       </v-tabs> 
       <v-tabs-items v-model="tab">
         <v-tab-item>
-          <plan-list/>
+          <plan-list :user="user"/>
         </v-tab-item>
         <v-tab-item>
 
         </v-tab-item>
         <v-tab-item>
-          <plan-list/>
+
         </v-tab-item>
         <v-tab-item>
-          <plan-list/>
+          
         </v-tab-item>
         <v-tab-item>
           <follow-list/>
@@ -43,19 +43,25 @@
 import PlanList from '~/components/mypage/PlanList.vue'
 import FollowList from '~/components/mypage/FollowList.vue'
 
-  export default {
-    components: {
-      PlanList,
-      FollowList
+export default {
+  components: {
+    PlanList,
+    FollowList
+  },
+  props: {
+    user: {
+      type: Object,
+      required: true,
     },
-    data () {
-      return {
-        tab: null,
-        items: [
-          '練習プラン', '活動報告', '参加', '気になる', 'フォロー', 'フォロワー'
-        ],
-        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-      }
-    },
-  }
+  },
+  data () {
+    return {
+      tab: null,
+      items: [
+        '練習プラン', '活動報告', '参加', '気になる', 'フォロー', 'フォロワー'
+      ],
+      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    }
+  },
+}
 </script>

--- a/front/components/mypage/PlanList.vue
+++ b/front/components/mypage/PlanList.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-row>
-      <v-col v-for="plan in plans" :key="plan.id">
+      <v-col v-for="plan in user.plan" :key="plan.id">
         <v-card
           class="mx-auto card-content"
           width="300"
@@ -50,6 +50,7 @@
           </v-card-text>
           <v-card-actions>
             <v-btn
+              @click.stop="getDetailPlan(plan)"
             >
               詳細情報
             </v-btn>
@@ -57,34 +58,40 @@
           </v-card-actions>
         </v-card>
       </v-col>
+      <my-plan-detail v-if="clickPlan" :plan="clickPlan" @close="closeDialog"/>
     </v-row>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions} from 'vuex'
+import myPlanDetail from '~/components/mypage/myPlanDetail'
 
 export default {
+  components: {
+    myPlanDetail
+  },
+  props: {
+    user: {
+      type: Object,
+    },
+  },
   data() {
     return {
       loading: false,
+      planDialog: false,
+      clickPlan: null
     }
   },
-  computed: {
-    ...mapGetters({
-      plans: 'plan/plans'
-    })
-  },
-  created() {
-    this.getPlans().then(() => {
-      this.loading = true
-    })
-  },
   methods: {
-    ...mapActions({
-      getPlans: 'plan/getPlans'
-    })
-  }
+    getDetailPlan(plan) {
+      this.clickPlan = plan
+      this.planDialog = true
+    },
+    closeDialog() {
+      this.planDialog = false
+      this.clickPlan = null
+    }
+  },
 }
 </script>
 

--- a/front/components/mypage/myPlanDetail.vue
+++ b/front/components/mypage/myPlanDetail.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-dialog
+    v-model="planDialog"
+    max-width="500px"
+  >
+    <v-card rounded="lg">
+      <v-card-title style="text-align:center">
+        自分の投稿
+      </v-card-title>
+      <div>
+        <v-chip 
+          color="primary"
+          outlined
+          style="margin-left: 15px"
+        >
+          {{ plan.event_cls }}
+        </v-chip>
+        <v-chip 
+          color="primary"
+          outlined
+          style="margin-left: 5px"
+        >
+          {{plan.train_strength}}
+        </v-chip>
+      </div>
+      <v-card-text class="mt-3" style="white-space:pre-line; word-wrap:break-word;">
+        <strong>{{plan.title}}</strong>
+        <v-spacer class="mt-5"></v-spacer>
+        <p>
+          <v-icon color="orange">mdi-calendar</v-icon>
+          開催日時 : <strong>{{$dayjs(plan.start_ymd).format('MM月DD日')}} {{$dayjs(plan.start_time).format('HH:mm')}}</strong>
+          所要時間 : <strong>{{plan.duration}}時間</strong></p>
+        <p>
+          <v-icon color="orange">mdi-map-marker</v-icon>
+          集合場所 : <strong>{{plan.place}}</strong>
+          エリア区分 : <strong>{{plan.prefecture}}</strong></p>
+        <v-spacer class="mt-5"></v-spacer>
+        <p style=" display:inline; border-bottom:solid 2px gray">詳細内容</p>
+        <p >{{plan.detail}}</p>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-btn
+          text
+          @click="planDialog = false"
+        >
+        <v-icon>mdi-close</v-icon>
+        <div style="line-height:24px">閉じる</div> 
+        </v-btn>
+        <div style="margin: 0 0 0 auto;">定員: [ 1 / {{plan.join_limit}} ]</div>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+export default {
+  props: {
+    plan: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      planDialog: true
+    }
+  },
+  methods: {
+  },
+  watch: {
+    planDialog() {
+      this.$emit("close")
+    }
+  }
+}
+</script>

--- a/front/store/plan.js
+++ b/front/store/plan.js
@@ -68,7 +68,12 @@ export const actions = {
           commit("flashMessage/setStatus", false, { root: true })
         }, 3000)
         commit("errorMessage/clearMessages", null, { root: true })
-        commit("setSuccessPost", true)
+        commit("setSuccessPost", true)    
+        this.$axios.get('api/v1/plans')
+          .then((response) => {
+            commit('setPlans', response)
+        })
+        
       })
       .catch((error) => {
         commit("flashMessage/setMessage", "投稿が失敗しました。", { root: true })


### PR DESCRIPTION
### 実装内容
- 練習プラン詳細情報をダイアログで表示
- プラン投稿後マイページへ遷移さ
- マイページ内で自身の投稿を一覧表示
- ユーザーアイコンの表示とクリックでユーザーページへ遷移

---
[![Image from Gyazo](https://i.gyazo.com/5b0681f7fea2f5a50726c9cfab2f3531.gif)](https://gyazo.com/5b0681f7fea2f5a50726c9cfab2f3531)
